### PR TITLE
Disable GraphQL metadata generation on build

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -37,7 +37,7 @@ ENV PORT ${PORT}
 
 #
 # Update schema
-RUN npm run graphql:codegen
+# RUN npm run graphql:codegen
 
 # Building app
 EXPOSE 3000

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -42,7 +42,7 @@ ENV NODE_ENV ${NODE_ENV}
 ENV PORT ${PORT}
 
 # Update schema
-RUN npm run graphql:codegen
+# RUN npm run graphql:codegen
 
 # Building app
 RUN npm run build


### PR DESCRIPTION
We should not fetch latest metadata from forbole servers configured in codegen.yml because we are not always using the latest version of the explorer itself. Also incase we add some additional custom queries, they will be lost when fetching from forbole server. During build we should fetch metadata from the local hasura API but since we have no means to easily edit the codegen.yml other than manually right now. We can just disable this, step and when we do some changes to the queries we just re-generate the metadata locally and commit it. I already did this for the latest changes.

Eventually when we get proper CI/CD process setup, we can return this step.