### PR TITLE
CUDOS-2603-fix-cw-20-contract-identifying

### DIFF
--- a/src/models/msg/cosmwasm/msg_execute_contract.ts
+++ b/src/models/msg/cosmwasm/msg_execute_contract.ts
@@ -38,20 +38,17 @@ class MsgExecuteContract {
   }
 
   static decodeMsg(data: string): string | undefined {
-    let message: string = data
+    let message: string = data;
     try {
       // Will throw if data is not valid base64 string
       const decodedMsg = JSON.parse(window.atob(data));
       if (Object.keys(decodedMsg).length) {
-        message = decodedMsg
+        message = decodedMsg;
       }
-
     } catch (error) {
-      console.log(`no need to decode: ${data}`)
-
-    } finally {
-      return message
+      console.log(`no need to decode: ${data}`);
     }
+    return message;
   }
 }
 

--- a/src/screens/token_details/utils.ts
+++ b/src/screens/token_details/utils.ts
@@ -27,7 +27,7 @@ export const fetchCW20TokenInfo = async (address: string): Promise<Cw20TokenInfo
     });
 
     if (!data || !data.data?.cw20token_info_by_pk) {
-      throw new Error("No tokenInfo")
+      throw new Error('No tokenInfo');
     }
 
     const tokenInfo = R.pathOr(defaultReturnValue, ['data', 'cw20token_info_by_pk'], data);

--- a/src/screens/token_details/utils.ts
+++ b/src/screens/token_details/utils.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import * as R from 'ramda';
 import { Cw20TokenInfo } from './types';
 
-export const fetchCW20TokenInfo = async (address: string):Promise<Cw20TokenInfo> => {
+export const fetchCW20TokenInfo = async (address: string): Promise<Cw20TokenInfo> => {
   const defaultReturnValue = {
     cw20TokenInfo: {
       address: '',
@@ -25,8 +25,12 @@ export const fetchCW20TokenInfo = async (address: string):Promise<Cw20TokenInfo>
       },
       query: Cw20TokenInfoDocument,
     });
-    const tokenInfo = R.pathOr(defaultReturnValue, ['data', 'cw20token_info_by_pk'], data);
 
+    if (!data || !data.data?.cw20token_info_by_pk) {
+      throw new Error("No tokenInfo")
+    }
+
+    const tokenInfo = R.pathOr(defaultReturnValue, ['data', 'cw20token_info_by_pk'], data);
     return {
       address,
       name: tokenInfo.name,


### PR DESCRIPTION
There is a case, when the graphql query does not error but return null for the cw20token_info_by_pk object inside data, therefore without error the tokenInfo is defined using the defaultReturnValue and returned with just the address being the query address, which mislead the entire calling logic.